### PR TITLE
Calendar bileşeni için dil desteği eklenmesi.

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -15,11 +15,11 @@ function Calendar({
 	showOutsideDays = true,
 	...props
 }: CalendarProps) {
-  const { lang } = useLocalization();
+	const { lang } = useLocalization();
   
 	return (
 		<DayPicker
-      locale={lang === "tr" ? tr : enUS}
+			locale={lang === "tr" ? tr : enUS}
 			showOutsideDays={showOutsideDays}
 			className={cn("p-3", className)}
 			classNames={{

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,7 +1,9 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type * as React from "react";
 import { DayPicker } from "react-day-picker";
+import { enUS, tr } from "date-fns/locale";
 
+import { useLocalization } from "@/hooks/use-localization";
 import { buttonVariants } from "@/components/ui/button.variants";
 import { cn } from "@/lib/utils";
 
@@ -13,8 +15,11 @@ function Calendar({
 	showOutsideDays = true,
 	...props
 }: CalendarProps) {
+  const { lang } = useLocalization();
+  
 	return (
 		<DayPicker
+      locale={lang === "tr" ? tr : enUS}
 			showOutsideDays={showOutsideDays}
 			className={cn("p-3", className)}
 			classNames={{


### PR DESCRIPTION
Uygulama dili Türkçe olmasına rağmen tarih seçme bileşeni İngilizce olarak görünüyordu. Eğer dil Türkçe ise tr İngilizce ise enUS olmasını sağladım.