### PR TITLE
style(onboarding): fixed shift in padding alignment on welcome screen

### DIFF
--- a/src/screens/onboarding/onboarding-welcome.tsx
+++ b/src/screens/onboarding/onboarding-welcome.tsx
@@ -22,7 +22,7 @@ export default function OnboardingWelcome({
 	const { m } = useLocalization();
 	return (
 		<motion.div
-			className="z-10 w-full pt-24 h-dvh px-12"
+			className="z-10 w-full py-12 h-dvh px-12"
 			exit={{ opacity: 0, scale: 0.95 }}
 			transition={{ duration: 0.3, type: "spring" }}
 		>


### PR DESCRIPTION
### Descripton
As in the picture content, I aligned the padding shift on the welcome screen in browsers such as Edge, Chrome, Safari

### Desktop (The button seems to be half)

<img src="https://github.com/user-attachments/assets/48f0d0aa-78cf-4c8d-b70d-05fcde8d366e" alt="giderim-welcome" width="400"/>

### Mobile (The button is not visible at all)

<img src="https://github.com/user-attachments/assets/260d5c9b-d164-4125-9944-e1c1119c9fa0" alt="giderim-welcome(mobile)" width="400"/>


