### PR TITLE
style(entry-drawer): sets the overhanging margin and space sizes in t…

### DIFF
--- a/src/components/custom/v2/entry-drawer.tsx
+++ b/src/components/custom/v2/entry-drawer.tsx
@@ -204,7 +204,7 @@ export const EntryDrawer = forwardRef<EntryDrawerRef, {}>((_, ref) => {
 				/>
 			</div>
 
-			<div className="flex flex-col items-center mb-8 grow justify-center relative">
+			<div className="flex flex-col items-center mb-6 grow justify-center relative">
 				<div className="mb-4 flex items-center w-full indent-11 pr-11">
 					<div
 						className={cn(
@@ -362,7 +362,7 @@ export const EntryDrawer = forwardRef<EntryDrawerRef, {}>((_, ref) => {
 				/>
 			</div>
 
-			<div className="grid grid-cols-3 gap-4">
+			<div className="grid grid-cols-3 gap-3 ">
 				{[1, 2, 3, 4, 5, 6, 7, 8, 9, decimalChar, 0].map((char) => (
 					<Button
 						key={char}


### PR DESCRIPTION
### Descripton
As in the image content, in browsers like Edge or Chrome, the number set in the `entry-drawer` moves off-screen towards the bottom of the screen

### Buttons protrude from the screen
![prod](https://github.com/user-attachments/assets/f1c55239-ba79-4dd3-a81e-7ed6d2774606)

### Compatible with gap and margin-bottom minimization
![dev](https://github.com/user-attachments/assets/8a2f551d-38a6-43aa-9a18-62d762010291)

